### PR TITLE
Fix link to the docs from the web interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
+README.pdf
 /web-wrapper/data/[0-9]*

--- a/README.md
+++ b/README.md
@@ -173,8 +173,8 @@ In case you want to remove outliers, delete the Ct value of the sample in the
 
 If you exported melting curves from the LightCycler 480, copy the content
  of the .txt file to your Excel file in a new sheet named "Melting curves".
-Delete the columns (both X and Sample) of empty wells. Do not forget to do
-the 'Tm calling' in the LightCycler 480 software.
+Delete the columns (both X and Sample) of empty wells.
+Do not forget to do the 'Tm calling' in the LightCycler 480 software.
 
 ![](doc-images/LinReg_melting_curves.png)
 

--- a/web-wrapper/index.php
+++ b/web-wrapper/index.php
@@ -4,7 +4,7 @@
  * Web wrapper for Bas Voesenek's qPCR analysis script.
  *
  * Created     : 2023-03-22
- * Modified    : 2023-04-20
+ * Modified    : 2023-10-19
  *
  * Copyright   : 2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
@@ -16,10 +16,6 @@ require ROOT_PATH . 'inc-lib.php';
 define('DATA_PATH', ROOT_PATH . 'data/');
 
 $sVersion = getVersion();
-// We link to the manual based on the first two numbers, to not have to create
-//  tags and not always have to adjust the version in the Python script.
-$aVersion = explode('.', $sVersion);
-$sVersionShort = implode('.', array_slice($aVersion, 0, 2));
 
 // Find out if we're using SSL.
 if ((!empty($_SERVER['HTTP_X_FORWARDED_PROTO']) && $_SERVER['HTTP_X_FORWARDED_PROTO'] == 'https') || (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] != 'off') || !empty($_SERVER['SSL_PROTOCOL'])) {
@@ -96,7 +92,8 @@ if ($sError) {
             Note, this process will take a while, but should be finished within a minute.
             When done, you will receive a zipped archive containing all resulting files.
             <BR><BR>
-            For more information about this software, please see <a href="https://github.com/bjbvoesenek/qPCR-analysis/blob/v<?= $sVersionShort; ?>.0/README.md">our manual</a>.
+            For more information about this software, please see
+             <a href="https://github.com/bjbvoesenek/qPCR-analysis/blob/v<?= $sVersion; ?>/README.md" target="_blank">our manual</a>.
         </div>
         <!-- Placeholder for errors. -->
         <div class="alert alert-danger mb-3 d-none" role="alert"></div>


### PR DESCRIPTION
### Fix link to the docs from the web interface, and other minor things
- Not only link to the X.X.0 versions, also link to X.X.X versions. The manual might still have changed.
- Also, open the link in a new window.
- Apply documentation standard. Each sentence should start on a new line.
- Add `README.pdf` to the `.gitignore`.